### PR TITLE
Comment out street suffix of Falls => FLS

### DIFF
--- a/lib/street_sweeper/constants.rb
+++ b/lib/street_sweeper/constants.rb
@@ -120,7 +120,7 @@ module StreetSweeper
       'extensions'  => 'exts',
       'extn'        => 'ext',
       'extnsn'      => 'ext',
-      'falls'       => 'fls',
+      # 'falls'       => 'fls',
       'ferry'       => 'fry',
       'field'       => 'fld',
       'fields'      => 'flds',

--- a/lib/street_sweeper/constants.rb
+++ b/lib/street_sweeper/constants.rb
@@ -200,7 +200,7 @@ module StreetSweeper
       'knoll'       => 'knl',
       'knolls'      => 'knls',
       'la'          => 'ln',
-      'lake'        => 'lk',
+      # 'lake'        => 'lk',
       'lakes'       => 'lks',
       'landing'     => 'lndg',
       'lane'        => 'ln',


### PR DESCRIPTION
This mapping breaks addresses in the Virginia city of Falls Church.